### PR TITLE
Security Label

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ jobs:
 
   analyze:
 
+    # Only run this action if the PR isn't a draft and it is labled as a `security` PR
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'security')
+
     env:
       XCODE_VERSION: 'Xcode_16.0'
 
@@ -24,7 +27,6 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     
-    if: github.event.pull_request.draft == false && github.event.label.name == 'security'
     runs-on: macos-15
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:


### PR DESCRIPTION
# Description

Adds conditional to only run CodeQL if the PR is not a draft PR and has the `security` label attached to it.
